### PR TITLE
this.paramEventIds included in instance to avoid overriding

### DIFF
--- a/jqrouter.js
+++ b/jqrouter.js
@@ -376,6 +376,7 @@ _define_('jqrouter', function(jqrouter) {
         },
         _instance_: function(self, routerEvents) {
             this.ids = [];
+            this.paramEventIds = [];
             this.__id__ = getUUID();
             this.$matched = false;
             this._state_ = {


### PR DESCRIPTION
Since this.paramEventIds is not initialised in the instance, the paramEventIds is getting shared by all the instances of jqrouter due to which the query params defined in routerEvents of different modules are getting replaced.